### PR TITLE
INTERLOK-3706 JPMS/Eclipse/J11 exclusion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,6 +119,13 @@ configurations {
   all*.exclude group: 'javax.validation', module: 'validation-api'
   all*.exclude group: 'javax.activation', module: 'activation'
   all*.exclude group: 'javax.activation', module: 'javax.activation-api'
+    
+  // module exclusions for java 11.
+  if (JavaVersion.current().ordinal() >= JavaVersion.VERSION_1_9.ordinal()) {
+    all*.exclude group: "xml-apis", module: "xml-apis"
+    all*.exclude group: "stax", module: "stax-api"
+    all*.exclude group: "org.apache.geronimo.specs", module: "geronimo-jta_1.1_spec"
+  }
 }
 
 configurations.all {


### PR DESCRIPTION
## Motivation

doing this so the project can be imported into eclipse

## Modification

the build file

## Result
 
you should be able to import the project into eclipse without having loads of errors